### PR TITLE
Other exports from casper module

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,6 +2,7 @@ var cli = require('cli'),
     cliOptions = cli.parse(phantom.args),
     opts = cliOptions.options,
     fs = require('fs'),
+    Casper = require('casper'),
 
 getPathForModule = function(what) {
   return fs.absolute(opts[what + '-path'] || opts['mocha-casperjs-path'] + '/../../node_modules/' + what)
@@ -15,15 +16,8 @@ if (fs.exists('mocha-casperjs.opts')) {
   }
 }
 
-// Load XPath helper
-try {
-  this.selectXPath = require('casper').selectXPath;
-} catch (e) {
-  casper.log('could not load XPath helper ' + e, 'debug', 'mocha-casperjs');
-}
-
 // Load casper
-this.casper = require('casper').create({
+this.casper = Casper.create({
   exitOnError: true,
   timeout: opts['casper-timeout'] || 10000,
   verbose: !!opts.verbose || opts['log-level'] === 'debug',
@@ -36,6 +30,7 @@ this.casper = require('casper').create({
     height: opts['viewport-height']
   }
 })
+this.xpath = Casper.selectXPath
 
 if (phantom.casperVersion.major !== 1 && phantom.capserVersion.minor < 1) {
   console.log('mocha-casperjs requires CasperJS >= 1.1.0-beta3')

--- a/test/all.coffee
+++ b/test/all.coffee
@@ -112,10 +112,11 @@ describe 'mocha-casperjs', ->
             'h1'.should.have.text 'Hello World!'
       , done
 
-    it 'should present casper XPath helper', (done) ->
+    it 'should expose the selectXPath module as the `xpath` global', (done) ->
       thisShouldPass
         test: ->
-          selectXPath.should.be.a.function
+          xpath.should.be.a('function')
+      , done
 
   describe 'CasperJS error handling', ->
     it 'should fail when a step fails', (done) ->


### PR DESCRIPTION
`casper` module provides an XPath selector helper called `selectXPath` in `casperjs`. 

I think it would be handy to expose `selectXPath` in `cli.js` like thus:

``` js
// Load xPath helper
this.selectXPath = require('casper').selectXPath;

// Load casper
this.casper = require('casper').create({
...
```

Are you cool with that - or do you have other ideas around structuring the `this` instance? Shall I make a PR?
