### PR TITLE
Fix if syntax in the bin/mocha-casperjs script

### DIFF
--- a/bin/mocha-casperjs
+++ b/bin/mocha-casperjs
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$1" == "--help" ] || [ "$1" == "-h" ] ; then
+if [ "$1" = "--help" ] || [ "$1" = "-h" ] ; then
  echo "   mocha-casperjs usage"
  echo "      options must be in the format of --option=value\n"
  echo "   --casper-timeout    Set Casper's timeout. Defaults to 5 seconds. You will want this less than Mocha's."


### PR DESCRIPTION
In Ubuntu, /bin/sh has changed from bash to dash, and the mocha-casperjs script produces a few of these errors:
`mocha-casperjs: 3: [: ==: unexpected operator`
due to [this syntax difference](https://wiki.ubuntu.com/DashAsBinSh#A.5B)

Using a single = works in both bash and dash correctly.
