### PR TITLE
Fix broken link to mocha opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The [selectXPath](http://casperjs.readthedocs.org/en/latest/selectors.html#index
 
 ## Command Line Options
 
-In addition to specifying options on the command line, you can add them to a `mocha-casperjs.opts` [like mocha.opts](http://visionmedia.github.io/mocha/#mocha.opts), except it looks for this file in the current directory.
+In addition to specifying options on the command line, you can add them to a `mocha-casperjs.opts` [like mocha.opts](http://mochajs.org/#mocha.opts), except it looks for this file in the current directory.
 
 ````
 --reporter


### PR DESCRIPTION
README was pointing to a dead link, I assume it should point to the opts part of the Mocha docs?