### PR TITLE
extended hack for #40 to work with win server 2008

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -57,7 +57,7 @@ try {
   this.chai.should()
 
   // ugly but isolated hack for #40
-  if (['function', 'object'].indexOf(typeof casper.__proto__.fetchText) && casper.__proto__.fetchText.toString().indexOf('fetchText') === -1) {
+  if (['function', 'object'].indexOf(typeof casper.__proto__.fetchText) > -1 && casper.__proto__.fetchText.toString().indexOf('fetchText') === -1) {
     casper.log('restoring Casper#fetchText', 'debug', 'mocha-casperjs')
     casper.__proto__.fetchText = function(selector) {
       this.checkStarted()

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -57,7 +57,7 @@ try {
   this.chai.should()
 
   // ugly but isolated hack for #40
-  if (typeof casper.__proto__.fetchText === 'function' && casper.__proto__.fetchText.toString().indexOf('fetchText') === -1) {
+  if (['function', 'object'].indexOf(typeof casper.__proto__.fetchText) && casper.__proto__.fetchText.toString().indexOf('fetchText') === -1) {
     casper.log('restoring Casper#fetchText', 'debug', 'mocha-casperjs')
     casper.__proto__.fetchText = function(selector) {
       this.checkStarted()


### PR DESCRIPTION
Hi there,

on Win Server 2008 we get an object instead of a function for casper.fetchText. The attached commit solved the problem for us (just extended the already existing hack). Would be nice if you can integrate it.

Best Regards

Sebastian