### PR TITLE
phantom args causing error, changed to system args as phantom args wa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 test/temptest.js
 .DS_Store
+*.idea

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,5 @@
 var cli = require('cli'),
-    cliOptions = cli.parse(phantom.args),
+    cliOptions = cli.parse(require('system').args.slice(1)),
     opts = cliOptions.options,
     fs = require('fs'),
     Casper = require('casper'),


### PR DESCRIPTION
PhantomJS 2.0 retired PhantomArgs http://phantomjs.org/api/phantom/property/args.html
the mocha-casperjs cli now needs to use system args or you'll get an undefined error for cliOptions.  