### PR TITLE
Allow custom PHANTOMJS_EXECUTABLE env var.

### DIFF
--- a/bin/mocha-casperjs
+++ b/bin/mocha-casperjs
@@ -33,7 +33,9 @@ if [ ! -z "$symLink" ]; then
   mcPath=$(cd $mcPath;cd $(dirname $symLink); pwd)
 fi
 
-PHANTOMJS_EXECUTABLE=$mcPath/../../phantomjs/bin/phantomjs
+if [ "$PHANTOMJS_EXECUTABLE" = "" ]; then
+  PHANTOMJS_EXECUTABLE=$mcPath/../../phantomjs/bin/phantomjs
+fi
 PATH=./node_modules/.bin:$PATH
 
 $mcPath/../../casperjs/bin/casperjs $mcPath/cli.js --mocha-casperjs-path=$mcPath/.. $*


### PR DESCRIPTION
The current implementation prevents users from using the `phantomjs-prebuilt` npm package which places the phantomjs executable in a different location. Preventing overwrites of the env var allows users to specify their own phantomjs executable.