### PR TITLE
Allow specifying opts file & test directory 

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,6 +4,7 @@ var cli = require('cli'),
     optsFile = opts.opts || 'mocha-casperjs.opts',
     fs = require('fs'),
     Casper = require('casper'),
+    extraArgs = [],
 
 getPathForModule = function(what) {
   return fs.absolute(opts[what + '-path'] || opts['mocha-casperjs-path'] + '/../../node_modules/' + what)
@@ -11,6 +12,7 @@ getPathForModule = function(what) {
 
 if (fs.exists(optsFile)) {
   var extraOpts = cli.parse(['blah'].concat(fs.read(optsFile).split('\n'))).options
+  extraArgs = cli.parse((fs.read(optsFile).split('\n'))).args;
 
   for (var p in extraOpts) {
     if (opts[p] == null) {
@@ -158,15 +160,18 @@ if (opts.slow) {
 
 // load the user's tests
 var tests = []
+
 if (cliOptions.args.length > 1) {
   // use tests if they specified them explicty
   tests = cliOptions.args.slice()
   tests.shift()
 } else {
-  // otherwise, load files from the test or tests directory like Mocha does
-  var testDir = 'test'
+  // otherwise, load files from the opts directory, test or tests directory like Mocha does
+  var testDir = extraArgs.length && extraArgs[0] || null
   if (!fs.isDirectory(testDir)) {
-    if (fs.isDirectory('tests')) {
+    if (fs.isDirectory('test')) {
+        testDir = 'test'
+    } else if (fs.isDirectory('tests')) {
       testDir = 'tests'
     } else {
       console.log('No tests specified. List them in the console, or add your tests to a "test" or "tests" folder in the current working directory.')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,7 @@
 var cli = require('cli'),
     cliOptions = cli.parse(require('system').args.slice(1)),
     opts = cliOptions.options,
+    optsFile = opts.opts || 'mocha-casperjs.opts',
     fs = require('fs'),
     Casper = require('casper'),
 
@@ -8,8 +9,8 @@ getPathForModule = function(what) {
   return fs.absolute(opts[what + '-path'] || opts['mocha-casperjs-path'] + '/../../node_modules/' + what)
 }
 
-if (fs.exists('mocha-casperjs.opts')) {
-  var extraOpts = cli.parse(['blah'].concat(fs.read('mocha-casperjs.opts').split('\n'))).options
+if (fs.exists(optsFile)) {
+  var extraOpts = cli.parse(['blah'].concat(fs.read(optsFile).split('\n'))).options
 
   for (var p in extraOpts) {
     if (opts[p] == null) {

--- a/test/all.coffee
+++ b/test/all.coffee
@@ -435,6 +435,8 @@ describe 'mocha-casperjs', ->
     describe 'mocha-casperjs.opts', ->
       afterEach ->
         fs.unlinkSync 'mocha-casperjs.opts'
+      after ->
+        fs.unlinkSync 'some-other-mocha-casperjs.opts'
 
       it 'should apply options from the file if available', (done) ->
         fs.writeFileSync 'mocha-casperjs.opts', '--reporter=json'
@@ -453,6 +455,19 @@ describe 'mocha-casperjs', ->
           params: ['--reporter=json']
           test: ->
             casper.page.settings.userAgent.should.equal 'mocha-casperjs-tests'
+        , (output, code) ->
+          results = JSON.parse output
+          results.stats.passes.should.equal 1
+          results.stats.failures.should.equal 0
+          done()
+
+      it 'should use an opts file from another location', (done) ->
+        fs.writeFileSync 'mocha-casperjs.opts', '--user-agent=wrong-optsfile'
+        fs.writeFileSync 'some-other-mocha-casperjs.opts', '--user-agent=some-other-mocha-casperjs-opts'
+        runMochaCasperJsTest
+          params: ['--reporter=json', '--opts=some-other-mocha-casperjs.opts']
+          test: ->
+            casper.page.settings.userAgent.should.equal 'some-other-mocha-casperjs-opts'
         , (output, code) ->
           results = JSON.parse output
           results.stats.passes.should.equal 1


### PR DESCRIPTION
Usage :

Option file path :

```
mocha-casperjs --opts=path/to/file/file.opts
```

Add test directory in the opts file:

```
test/casperjs/tests
[other options]
```

Fix #95